### PR TITLE
fix(v14): adapt to Babele 2.8.0 API and v14 deprecations

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,7 @@
     "verified": "13"
   },
   "esmodules": [
-    "babele-ondemand-patch.js","babele.js","npc/NPCTranslator.js"
+    "babele.js","npc/NPCTranslator.js"
   ],
   "changelog": "https://github.com/fvtt-cn/pf2e_compendium_chn/releases/tag/1.0.1",
   "version": "1.0.1",

--- a/npc/NPCTranslator.js
+++ b/npc/NPCTranslator.js
@@ -1,4 +1,13 @@
-import {CompendiumMapping} from "../../babele/script/compendium-mapping.js";
+import {DocumentMapping} from "../../babele/script/mapping/document-mapping.js";
+
+// Babele 2.8.0 renamed CompendiumMapping → DocumentMapping and now requires
+// {identityExtractors, converterRegistry} from the running Babele facade.
+function buildItemMapping(definition) {
+    return new DocumentMapping("Item", definition, {
+        identityExtractors: game.babele.identityExtractorRegistry(),
+        converterRegistry: game.babele.converterRegistry,
+    });
+}
 
 // Register token setting
 Hooks.once("init", () => {
@@ -281,7 +290,7 @@ class NPCTranslator {
                 }
                 let translated = false;
                 if (translations) {
-                    let dynamicMapping = new CompendiumMapping("Item", this.dict.itemMapping);
+                    let dynamicMapping = buildItemMapping(this.dict.itemMapping);
 
                     let translation;
                     if (Array.isArray(translations)) {
@@ -293,7 +302,7 @@ class NPCTranslator {
                         let slug = this.sluggify(entry.name.replace("strike-", ""));
                         translated = true;
                         let translatedData = dynamicMapping.map(entry, translation);
-                        arr[index] = mergeObject(entry, mergeObject(translatedData, { translated: true }));
+                        arr[index] = foundry.utils.mergeObject(entry, foundry.utils.mergeObject(translatedData, { translated: true }));
                         if (!entry.system.slug) entry.system.slug = slug;
                     }
                 }
@@ -328,7 +337,7 @@ class NPCTranslator {
                 // Use manual added translations from json
                 let translated = false;
                 if (translations) {
-                    let dynamicMapping = new CompendiumMapping("Item", this.dict.itemMapping);
+                    let dynamicMapping = buildItemMapping(this.dict.itemMapping);
 
                     let translation;
                     if (Array.isArray(translations)) {
@@ -339,7 +348,7 @@ class NPCTranslator {
                     if (translation) {
                         translated = true;
                         let translatedData = dynamicMapping.map(entry, translation);
-                        arr[index] = mergeObject(entry, mergeObject(translatedData, { translated: true }));
+                        arr[index] = foundry.utils.mergeObject(entry, foundry.utils.mergeObject(translatedData, { translated: true }));
                     }
                 }
 
@@ -598,7 +607,7 @@ class Dictionary {
 
         // Use a translation provided in the localized actor data
         if (typeof translations != "undefined" && Object.keys(translations).includes(`equipment-${item.name}`)) {
-            let dynamicMapping = new CompendiumMapping("Item", itemMapping);
+            let dynamicMapping = buildItemMapping(itemMapping);
 
             let translation;
             if (Array.isArray(translations)) {
@@ -608,7 +617,7 @@ class Dictionary {
             }
             if (translation) {
                 let translatedData = dynamicMapping.map(item, translation);
-                translatedItem = mergeObject(item, mergeObject(translatedData, { translated: true }));
+                translatedItem = foundry.utils.mergeObject(item, foundry.utils.mergeObject(translatedData, { translated: true }));
             }
             // Translate non-compendium items and items with altered names
         } else if (Object.keys(this.translations.Item).includes(item.name.toLowerCase())) {

--- a/npc/NPCTranslator.js
+++ b/npc/NPCTranslator.js
@@ -561,7 +561,8 @@ class Dictionary {
             }
         }
 
-        let translation = game.babele.packs.get(compendium).translate(data);
+        // Babele 2.8.0 dropped `babele.packs` in favor of the public translate(pack, data) facade.
+        let translation = game.babele.translate(compendium, data);
         if (translation.name.search("/") != -1)
             translation.name = translation.name.substring(0, translation.name.search("/"));
 


### PR DESCRIPTION
## Summary

Restore compatibility with Babele 2.8.x on Foundry v14. The module
currently fails to load on a v14 + Babele 2.8.x stack because of three
load-time breakages introduced by the 2.8.0 refactor (see Babele's
[Developer Migration Notes for 2.8.0](https://gitlab.com/riccisi/foundryvtt-babele/-/wikis/Developer-Migration-Notes-for-2.8.0)).

### 1. `babele-ondemand-patch.js` is unsalvageable on Babele 2.8.x

The on-demand patch deep-monkey-patches Babele internals that no longer
exist:

| Removed / moved API used by the patch | Babele 2.8.x replacement |
| --- | --- |
| `import('/modules/babele/script/translated-compendium.js')` | `compendium/mapped-compendium.js` exporting `MappedCompendium` (constructor now requires `{identityExtractors, converterRegistry, documentMappings}`) |
| `babele.packs` | `babele.mappedCompendiums` (use `.get()` / `.translated()`) |
| `babele.modules` / `babele.supported()` / `babele.getCollection()` / `babele.systemTranslationsDir` | moved into private `#catalog` / `#translationRegistry` |
| `Babele.PACK_FOLDER_TRANSLATION_NAME_SUFFIX` | removed |
| `babele.translations` as an `Array` | now a `CompendiumTranslations` object |

Rewriting the patch against the new architecture is a substantial
project; in the meantime, dropping it from `esmodules` lets the module
fall back to Babele 2.8.x's own loader, which is fast enough on v14 that
the custom on-demand layer is no longer load-bearing. On-demand actor
translation is already provided by Babele's built-in
`OnDemandTranslateDialog` (`game.babele.translateActor`).

The file itself is left in the repo so the on-demand work can be
revived later on top of the new API.

### 2. `NPCTranslator.js` imports the removed `CompendiumMapping`

`../../babele/script/compendium-mapping.js` returns 404 on Babele 2.8.x
- the top-level `import` fails, the whole file fails to load,
`game.npcTrans` never gets registered, and the four `npc-*` converters
registered in `babele.js` then throw whenever PF2e bestiary packs are
translated.

Replaced with the new `DocumentMapping`
(`babele/script/mapping/document-mapping.js`). The new constructor
requires `{identityExtractors, converterRegistry}`, both exposed on the
`game.babele` facade (`identityExtractorRegistry()` and
`converterRegistry`). A small `buildItemMapping(definition)` helper
centralizes that wiring.

### 3. `mergeObject(...)` is gone in v14

Three sites still use the bare global `mergeObject`, deprecated since
v12 and removed in v14. Qualified to `foundry.utils.mergeObject(...)`.

## Test plan

- [x] Foundry v14 + Babele 2.8.1 + PF2e: module loads with no console
      errors at startup
- [x] PF2e bestiary compendium index titles render in Chinese
- [x] Importing an NPC from a bestiary pack runs the `npc-*` converters
      without errors (portrait / token name / `data` / embedded items)
- [x] No `mergeObject is not a function` in console
- [x] No `Failed to fetch /modules/babele/script/translated-compendium.js`
      in console
