### PR TITLE
fix(translations): use structured converter for prerequisites and prototypeToken

### DIFF
--- a/en-US/clerics.clerics-feats.json
+++ b/en-US/clerics.clerics-feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Clerics+ Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Arise to Sainthood": {

--- a/en-US/impossible-lands.impossible-lands-feats.json
+++ b/en-US/impossible-lands.impossible-lands-feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Impossible Lands+ Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "A Soul's Truth": {

--- a/en-US/magus.magus-feats.json
+++ b/en-US/magus.magus-feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Ablative Barrier Block": {

--- a/en-US/oracles.oracle-feats.json
+++ b/en-US/oracles.oracle-feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Oracles+ Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Artifact Relic": {

--- a/en-US/pf2e-feats-plus.misc.json
+++ b/en-US/pf2e-feats-plus.misc.json
@@ -1,7 +1,14 @@
 {
     "label": "Miscellaneous",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Activate Glyph": {

--- a/en-US/pf2e-feats-plus.player-options.json
+++ b/en-US/pf2e-feats-plus.player-options.json
@@ -1,7 +1,14 @@
 {
     "label": "Player Options",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "A Home in Every Port+": {

--- a/en-US/pf2e-heresy-of-the-whispering-way.feats.json
+++ b/en-US/pf2e-heresy-of-the-whispering-way.feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Animate Soul Cage": {

--- a/en-US/pf2e-kitsune.kitsune-Feats.json
+++ b/en-US/pf2e-kitsune.kitsune-Feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Kitsune - Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Adroit Athleticism": {

--- a/zh-CN/barbarians.barbarians-feats.json
+++ b/zh-CN/barbarians.barbarians-feats.json
@@ -1,5 +1,12 @@
 {
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     }
 }

--- a/zh-CN/battlezoo-bestiary-pf2e.pf2e-battlezoo-bestiary.json
+++ b/zh-CN/battlezoo-bestiary-pf2e.pf2e-battlezoo-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Afneith": {

--- a/zh-CN/clerics.clerics-feats.json
+++ b/zh-CN/clerics.clerics-feats.json
@@ -1,6 +1,13 @@
 {
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "label": "牧师+专长 Clerics+ Feats",
     "entries": {

--- a/zh-CN/impossible-lands.impossible-lands-feats.json
+++ b/zh-CN/impossible-lands.impossible-lands-feats.json
@@ -1,6 +1,13 @@
 {
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "label": "惊世奇土+ 专长 Impossible Lands+ Feats",
     "entries": {

--- a/zh-CN/magus.magus-feats.json
+++ b/zh-CN/magus.magus-feats.json
@@ -1,7 +1,14 @@
 {
     "label": "魔战士+专长 Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Ablative Barrier Block": {

--- a/zh-CN/oracles.oracle-feats.json
+++ b/zh-CN/oracles.oracle-feats.json
@@ -1,6 +1,13 @@
 {
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "label": "先知+专长 Oracles+ Feats",
     "entries": {

--- a/zh-CN/pf2e-animal-companions.AC-Evolution-Feats.json
+++ b/zh-CN/pf2e-animal-companions.AC-Evolution-Feats.json
@@ -1,7 +1,14 @@
 {
     "label": "幻灵进化专长 Evolution Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value",
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        },
         "description": "system.description.value",
         "gmnote": "system.description.gm"
     },

--- a/zh-CN/pf2e-feats-plus.misc.json
+++ b/zh-CN/pf2e-feats-plus.misc.json
@@ -295,6 +295,13 @@
     },
     "label": "混杂效果 Miscellaneous",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e-feats-plus.player-options.json
+++ b/zh-CN/pf2e-feats-plus.player-options.json
@@ -2994,6 +2994,13 @@
         }
     },
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e-heresy-of-the-whispering-way.feats.json
+++ b/zh-CN/pf2e-heresy-of-the-whispering-way.feats.json
@@ -1,7 +1,14 @@
 {
     "label": "Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     },
     "entries": {
         "Animate Soul Cage": {

--- a/zh-CN/pf2e-kitsune.kitsune-Feats.json
+++ b/zh-CN/pf2e-kitsune.kitsune-Feats.json
@@ -1,6 +1,13 @@
 {
     "label": "狐妖 - 专长 Kitsune - Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.abomination-vaults-bestiary.json
+++ b/zh-CN/pf2e.abomination-vaults-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Afflicted Irnakurse": {

--- a/zh-CN/pf2e.age-of-ashes-bestiary.json
+++ b/zh-CN/pf2e.age-of-ashes-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Accursed Forge-Spurned": {

--- a/zh-CN/pf2e.agents-of-edgewatch-bestiary.json
+++ b/zh-CN/pf2e.agents-of-edgewatch-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Acidic Poison Cloud Trap": {

--- a/zh-CN/pf2e.blood-lords-bestiary.json
+++ b/zh-CN/pf2e.blood-lords-bestiary.json
@@ -28,7 +28,14 @@
         "senses": "system.traits.senses.value",
         "hp": "system.attributes.hp.details",
         "blurb": "system.details.blurb",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Aeolaeka": {

--- a/zh-CN/pf2e.book-of-the-dead-bestiary.json
+++ b/zh-CN/pf2e.book-of-the-dead-bestiary.json
@@ -33,7 +33,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Beetle Carapace": {

--- a/zh-CN/pf2e.crown-of-the-kobold-king-bestiary.json
+++ b/zh-CN/pf2e.crown-of-the-kobold-king-bestiary.json
@@ -18,6 +18,13 @@
             "path": "items",
             "converter": "npc-item-translation"
         },
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.extinction-curse-bestiary.json
+++ b/zh-CN/pf2e.extinction-curse-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abberton Ruffian": {

--- a/zh-CN/pf2e.fall-of-plaguestone-bestiary.json
+++ b/zh-CN/pf2e.fall-of-plaguestone-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Alchemical Drudge": {

--- a/zh-CN/pf2e.fists-of-the-ruby-phoenix-bestiary.json
+++ b/zh-CN/pf2e.fists-of-the-ruby-phoenix-bestiary.json
@@ -33,7 +33,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abbot Tsujon": {

--- a/zh-CN/pf2e.gatewalkers-bestiary.json
+++ b/zh-CN/pf2e.gatewalkers-bestiary.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Amelekana": {

--- a/zh-CN/pf2e.howl-of-the-wild-bestiary.json
+++ b/zh-CN/pf2e.howl-of-the-wild-bestiary.json
@@ -2509,7 +2509,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "label": "荒野之嚎 Howl of the Wild"
 }

--- a/zh-CN/pf2e.kingmaker-bestiary.json
+++ b/zh-CN/pf2e.kingmaker-bestiary.json
@@ -33,7 +33,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Aecora Silverfire": {

--- a/zh-CN/pf2e.lost-omens-bestiary.json
+++ b/zh-CN/pf2e.lost-omens-bestiary.json
@@ -16580,6 +16580,13 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.malevolence-bestiary.json
+++ b/zh-CN/pf2e.malevolence-bestiary.json
@@ -27,7 +27,14 @@
         "hazarddescription": "system.details.description",
         "reset": "system.details.reset",
         "routine": "system.details.routine",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Algea": {

--- a/zh-CN/pf2e.menace-under-otari-bestiary.json
+++ b/zh-CN/pf2e.menace-under-otari-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Animated Armor (BB)": {

--- a/zh-CN/pf2e.night-of-the-gray-death-bestiary.json
+++ b/zh-CN/pf2e.night-of-the-gray-death-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Chakanaj": {

--- a/zh-CN/pf2e.one-shot-bestiary.json
+++ b/zh-CN/pf2e.one-shot-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Auldegrund Grimcarver": {

--- a/zh-CN/pf2e.outlaws-of-alkenstar-bestiary.json
+++ b/zh-CN/pf2e.outlaws-of-alkenstar-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "\"Lucky\" Lanks": {

--- a/zh-CN/pf2e.pathfinder-bestiary-2.json
+++ b/zh-CN/pf2e.pathfinder-bestiary-2.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Interlocutor": {

--- a/zh-CN/pf2e.pathfinder-bestiary-3.json
+++ b/zh-CN/pf2e.pathfinder-bestiary-3.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Mobogo": {

--- a/zh-CN/pf2e.pathfinder-bestiary.json
+++ b/zh-CN/pf2e.pathfinder-bestiary.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Ankhrav": {

--- a/zh-CN/pf2e.pathfinder-monster-core-2.json
+++ b/zh-CN/pf2e.pathfinder-monster-core-2.json
@@ -27,7 +27,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Feathered Bear": {

--- a/zh-CN/pf2e.pathfinder-monster-core.json
+++ b/zh-CN/pf2e.pathfinder-monster-core.json
@@ -14889,7 +14889,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "label": "怪物核心 Monster Core"
 }

--- a/zh-CN/pf2e.pathfinder-npc-core.json
+++ b/zh-CN/pf2e.pathfinder-npc-core.json
@@ -27,7 +27,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Local Herbalist": {

--- a/zh-CN/pf2e.pfs-introductions-bestiary.json
+++ b/zh-CN/pf2e.pfs-introductions-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Ancient Summoning Rune": {

--- a/zh-CN/pf2e.pfs-season-1-bestiary.json
+++ b/zh-CN/pf2e.pfs-season-1-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "'Zombie' Flesh Golem (3-4)": {

--- a/zh-CN/pf2e.pfs-season-2-bestiary.json
+++ b/zh-CN/pf2e.pfs-season-2-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abyssal Firestorm Surge (7-8)": {

--- a/zh-CN/pf2e.pfs-season-3-bestiary.json
+++ b/zh-CN/pf2e.pfs-season-3-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Advanced Eltha Embercall (9-10)/Eltha Embercall (11-12)": {

--- a/zh-CN/pf2e.pfs-season-4-bestiary.json
+++ b/zh-CN/pf2e.pfs-season-4-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "A Broken Promise (1-2)": {

--- a/zh-CN/pf2e.prey-for-death-bestiary.json
+++ b/zh-CN/pf2e.prey-for-death-bestiary.json
@@ -1466,6 +1466,13 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.quest-for-the-frozen-flame-bestiary.json
+++ b/zh-CN/pf2e.quest-for-the-frozen-flame-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abyss-warped Trees": {

--- a/zh-CN/pf2e.rage-of-elements-bestiary.json
+++ b/zh-CN/pf2e.rage-of-elements-bestiary.json
@@ -2630,6 +2630,13 @@
         "languages": "system.traits.languages.custom",
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.season-of-ghosts-bestiary.json
+++ b/zh-CN/pf2e.season-of-ghosts-bestiary.json
@@ -2941,6 +2941,13 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/pf2e.seven-dooms-for-sandpoint-bestiary.json
+++ b/zh-CN/pf2e.seven-dooms-for-sandpoint-bestiary.json
@@ -1947,7 +1947,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "label": "沙尖七灾 Seven Dooms for Sandpoint Bestiary"
 }

--- a/zh-CN/pf2e.shadows-at-sundown-bestiary.json
+++ b/zh-CN/pf2e.shadows-at-sundown-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abridan Ashau": {

--- a/zh-CN/pf2e.sky-kings-tomb-bestiary.json
+++ b/zh-CN/pf2e.sky-kings-tomb-bestiary.json
@@ -3087,7 +3087,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "label": "巡天王冢 Sky King's Tomb"
 }

--- a/zh-CN/pf2e.spore-war-bestiary.json
+++ b/zh-CN/pf2e.spore-war-bestiary.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Fungal Forge": {

--- a/zh-CN/pf2e.strength-of-thousands-bestiary.json
+++ b/zh-CN/pf2e.strength-of-thousands-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Abendego Brute": {

--- a/zh-CN/pf2e.the-enmity-cycle-bestiary.json
+++ b/zh-CN/pf2e.the-enmity-cycle-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Amar": {

--- a/zh-CN/pf2e.the-slithering-bestiary.json
+++ b/zh-CN/pf2e.the-slithering-bestiary.json
@@ -18,8 +18,14 @@
             "path": "items",
             "converter": "npc-item-translation"
         },
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
-    "entries": {
-    }
+    "entries": {}
 }

--- a/zh-CN/pf2e.triumph-of-the-tusk-bestiary.json
+++ b/zh-CN/pf2e.triumph-of-the-tusk-bestiary.json
@@ -28,7 +28,14 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Hold Warrior (Forge)": {

--- a/zh-CN/pf2e.troubles-in-otari-bestiary.json
+++ b/zh-CN/pf2e.troubles-in-otari-bestiary.json
@@ -34,7 +34,14 @@
         "stealthdetails": "system.attributes.stealth.details",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Brimstone Rat": {

--- a/zh-CN/pf2e.vehicles.json
+++ b/zh-CN/pf2e.vehicles.json
@@ -5,7 +5,14 @@
         "crew": "system.details.crew",
         "pilotingCheck": "system.details.pilotingCheck",
         "speed": "system.details.speed",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     },
     "entries": {
         "Adaptable Paddleboat": {

--- a/zh-CN/pf2e.war-of-immortals-bestiary.json
+++ b/zh-CN/pf2e.war-of-immortals-bestiary.json
@@ -766,6 +766,13 @@
         "languages": "system.traits.languages.custom",
         "ac": "system.attributes.ac.details",
         "di": "system.traits.di.custom",
-        "prototypeToken": "prototypeToken"
+        "prototypeToken": {
+            "path": "prototypeToken",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "name": "name"
+            }
+        }
     }
 }

--- a/zh-CN/witches.witches-feats.json
+++ b/zh-CN/witches.witches-feats.json
@@ -262,6 +262,13 @@
     },
     "label": "女巫+专长 Witches+ Feats",
     "mapping": {
-        "prerequisites": "system.prerequisites.value"
+        "prerequisites": {
+            "path": "system.prerequisites.value",
+            "converter": "structured",
+            "cardinality": "many",
+            "mapping": {
+                "value": "value"
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fix two long-standing mapping declarations that Babele 2.8.0 now refuses to apply.

### Why

Babele 2.8.0 added a strict structural check to its `PrimitiveConverter`
(`babele/script/converter/primitive-converter.js`):

```js
_invalidStaticTranslation(originalValue, translatedValue) {
    if (Array.isArray(translatedValue) || this._isPlainObject(translatedValue)) {
        return "structural";    // skip the field
    }
    ...
}
```

Plain string-path mappings now only accept primitive translation payloads
(string / number / boolean). Two long-standing mappings in this module
ship complex translation values, so they are silently skipped on 2.8.x:

| Mapping | Translation value shape | Affected files |
| --- | --- | --- |
| `"prerequisites": "system.prerequisites.value"` | `[{ value: "..." }, ...]` | 12 zh-CN / 8 en-US |
| `"prototypeToken": "prototypeToken"` | `{ name: "..." }` | 45 zh-CN |

The second one was actively dangerous on older Babele: `PrimitiveConverter`
would replace the entire `prototypeToken` object with `{ name: "..." }`,
wiping any other token configuration (display modes, vision, light, etc.)
that the user had set on bestiary entries. The new strict check
protected users from data loss; the proper fix is to declare the mapping
with the `structured` converter so only the inner `name` field is touched.

### What

Both mappings are now declared as `structured` converters with the right
cardinality and a sub-mapping pointing at the leaf field that actually
holds translatable text:

```json
"prerequisites": {
    "path": "system.prerequisites.value",
    "converter": "structured",
    "cardinality": "many",
    "mapping": { "value": "value" }
}

"prototypeToken": {
    "path": "prototypeToken",
    "converter": "structured",
    "cardinality": "one",
    "mapping": { "name": "name" }
}
```

65 files rewritten with a small Python script (no manual editing).
JSON indentation, key ordering and trailing-newline conventions are
preserved byte-for-byte against the existing files.

## Test plan

- [x] All 65 modified JSON files still parse as valid JSON
- [x] On Foundry v14 + Babele 2.8.1 + PF2e: feat prerequisites display
      Chinese values inside the feat sheet (previously stayed in English)
- [x] On Foundry v14 + Babele 2.8.1 + PF2e: bestiary actor token names
      display Chinese values (previously stayed in English)
- [x] No `Babele | invalid translation payload for static field` warnings
      in console for `prerequisites` or `prototypeToken`
- [ ] Note: feat prerequisite filtering by 3rd-party modules such as
      [PF2E Feat Filter](https://foundryvtt.com/packages/pf2e-feat-filter)
      reads the same `system.prerequisites.value[].value` strings and
      will see them in their translated form after this PR. The PF2e
      system itself does not parse prerequisites, so the system is
      unaffected. Filter modules that match against English literals
      may need to consult both Chinese and English at runtime.

## Related

- #41 (`fix(v14): adapt to Babele 2.8.0 API and v14 deprecations`) —
  ships independently; this PR is purely a translation-data fix and
  does not touch JS code.
